### PR TITLE
Show 'exclude this facet' icons automatically

### DIFF
--- a/custom/01ALLIANCE_UO-UO/css/20-fixes.css
+++ b/custom/01ALLIANCE_UO-UO/css/20-fixes.css
@@ -80,3 +80,8 @@ div.date-range-inputs > md-input-container:nth-of-type(3) {
 h3.item-title span.text-in-brackets {
 	opacity: .55;
 }
+
+/* Add ability to see "exclude this facet" icons without hovering */
+.section-content .md-chips .md-chip .md-chip-remove-container .md-button {
+	opacity: 1;
+}


### PR DESCRIPTION
Update opacity of 'exclude this facet' icons so that users no longer have to hover over the icon for it to be visible on non-mobile views. 