### PR TITLE
Remove duplicate quicklink on homepage

### DIFF
--- a/custom/01ALLIANCE_UO-UO/html/homepage/homepage_en.html
+++ b/custom/01ALLIANCE_UO-UO/html/homepage/homepage_en.html
@@ -45,9 +45,6 @@
           <li>
             <a href="https://researchguides.uoregon.edu/usinglibrarysearch">LibrarySearch Help</a>
           </li>
-          <li>
-            <a href="https://researchguides.uoregon.edu/usinglibrarysearch#s-lg-box-19119757">What am I searching?</a>
-          </li>
         </ul>
       </md-card-content>
     </md-card>


### PR DESCRIPTION
Closes #90 

## Before
<img width="372" height="192" alt="Quicklinks menu with two links" src="https://github.com/user-attachments/assets/3dbbe6d7-390c-470e-9739-af7e1860a627" />

## After
<img width="355" height="165" alt="Quicklinks menu with one link" src="https://github.com/user-attachments/assets/555f6f65-99b9-46dc-96b3-c9b63bde434e" />
