### PR TITLE
Add customizations for Collection Discovery

### DIFF
--- a/custom/01ALLIANCE_UO-UO/css/20-fixes.css
+++ b/custom/01ALLIANCE_UO-UO/css/20-fixes.css
@@ -100,13 +100,13 @@ prm-location-holdings {
 }
 
 /* Fix styling of the breadcrumbs – also visible in the full title display */
-prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color {
+.collection-header-inner div prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color {
 	box-shadow: none;
 	color: #FFF !important;
 	line-height: 24px;
 }
  
-prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color:hover {
+.collection-header-inner div prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color:hover {
 	color: #104735 !important;
 	background: #FFF !important;
 	line-height: 24px;
@@ -150,6 +150,25 @@ prm-collection-discovery-view-switcher .md-button.is-active:hover:not([disabled]
 
 prm-save-to-favorites-button .pin-button {
 	color: #104735 !important;
+}
+
+.collectionsLinks prm-collection-navigation-breadcrumbs-item a {
+	color: #104735 !important;
+}
+
+.collectionsLinks prm-collection-navigation-breadcrumbs-item a:hover,
+.collectionsLinks prm-collection-navigation-breadcrumbs-item a:focus {
+  background-color: rgba(76,180,69,.1) !important;
+  box-shadow: inset 0 -1px 0 0 rgba(40,145,34,.5) !important;
+}
+
+prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color {
+	color: #104735 !important;
+}
+ 
+prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color:hover {
+	background-color: rgba(76,180,69,.1) !important;
+	box-shadow: inset 0 -1px 0 0 rgba(40,145,34,.5) !important;
 }
 
 /* Display of author and year */

--- a/custom/01ALLIANCE_UO-UO/css/20-fixes.css
+++ b/custom/01ALLIANCE_UO-UO/css/20-fixes.css
@@ -90,3 +90,84 @@ h3.item-title span.text-in-brackets {
 prm-location-holdings {
 	margin: 1em 0;
 }
+
+/* Add Collections Discovery Customizations
+(https://primoviews.org/combined_code/collection-discovery/) */
+
+/* Header */
+.collection-info {
+	color: #FFF !important;
+}
+
+/* Fix styling of the breadcrumbs – also visible in the full title display */
+prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color {
+	box-shadow: none;
+	color: #FFF !important;
+	line-height: 24px;
+}
+ 
+prm-collection-navigation-breadcrumbs-item .md-button.button-as-link.link-alt-color:hover {
+	color: #104735 !important;
+	background: #FFF !important;
+	line-height: 24px;
+}
+
+prm-collection-navigation-breadcrumbs-item.root-item .md-button {
+	line-height: 0 !important;
+}
+
+/* Update link and button colors */
+
+prm-gallery-item .collection-element .item-title {
+	color: #104735 !important;
+}
+
+prm-gallery-collection .collection-folder .collection-header {
+	color: #104735 !important;
+}
+
+prm-collection-discovery-view-switcher .md-button.is-active, prm-collection-discovery-view-switcher .md-button.is-active:focus, prm-collection-discovery-view-switcher .md-button.is-active:hover {
+	color: #104735;
+}
+
+prm-collection-discovery-view-switcher .md-button.is-active._md-focused:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active.hovered:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active.md-focused:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:focus._md-focused:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:focus.hovered:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:focus.md-focused:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:focus:focus:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:focus:hover:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:focus:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:hover._md-focused:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:hover.hovered:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:hover.md-focused:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:hover:focus:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:hover:hover:not([disabled]),
+prm-collection-discovery-view-switcher .md-button.is-active:hover:not([disabled]) {
+	background-color: #104735;
+}
+
+prm-save-to-favorites-button .pin-button {
+	color: #104735 !important;
+}
+
+/* Display of author and year */
+prm-gallery-item-after {
+    padding: 20px 15px;
+    display: block;
+    margin-top: -30px;
+}
+
+prm-gallery-item-after div {
+    margin-bottom: -40px;
+    margin-top: -20px;
+}
+
+.is-grid-view prm-gallery-item .collection-element {
+    padding: 15px;
+}
+
+prm-gallery-item .collection-element .item-title {
+   padding-bottom: 30px;
+}

--- a/custom/01ALLIANCE_UO-UO/js/10-uo.js
+++ b/custom/01ALLIANCE_UO-UO/js/10-uo.js
@@ -204,3 +204,33 @@ app.component('prmSearchResultAvailabilityLineAfter', {
   template: '\n<hathi-trust-availability msg="Check availability in HathiTrust"></hathi-trust-availability>',
   controller: 'prmSearchResultAvailabilityLineAfterController'
 });
+
+/* Collections Discovery Authors/Date display 
+ * https://primoviews.org/combined_code/collection-discovery/ */
+app.component("prmGalleryItemAfter", {
+    bindings: {
+        parentCtrl: "<"
+    },
+    controller: function () {
+        var $ctrl = this;
+
+        $ctrl.$onInit = function () {
+            try {
+                $ctrl.author = $ctrl.parentCtrl.item.pnx.addata.au[0];
+            } catch (e) {
+                $ctrl.author = "";
+            }
+            try {
+                $ctrl.date = $ctrl.parentCtrl.item.pnx.display.creationdate[0];
+            } catch (e) {
+                $ctrl.date = "";
+            }
+            $ctrl.hasDate = !!$ctrl.date;
+            $ctrl.hasAuthor = !!$ctrl.author;
+        };
+    },
+    template: `
+    <div ng-if="$ctrl.hasDate">{{$ctrl.date}}</div>
+    <div ng-if="$ctrl.hasAuthor">{{$ctrl.author}}</div>
+    `,
+});


### PR DESCRIPTION
Closes #92 

## Changes
- Adds Authors/Dates to collection items
- Updates branding of Collection Discovery pages

## Before
<img width="2242" height="3582" alt="Collection Discovery before customizations" src="https://github.com/user-attachments/assets/4ce82d40-5d4f-471f-b3a8-cccf9158c449" />

## After
<img width="2926" height="4022" alt="Collection Discovery after customizations" src="https://github.com/user-attachments/assets/5fec36a8-4471-4b30-b985-986ddcf32d92" />


