### PR TITLE
Restore navigation menu on service pages

### DIFF
--- a/custom/01ALLIANCE_UO-UO/css/20-fixes.css
+++ b/custom/01ALLIANCE_UO-UO/css/20-fixes.css
@@ -190,3 +190,8 @@ prm-gallery-item-after div {
 prm-gallery-item .collection-element .item-title {
    padding-bottom: 30px;
 }
+
+/* Fix menu not showing up on service pages */
+prm-topbar .isDeposit, prm-topbar .isServicePage, prm-topbar .isSummonOverAlma {
+	display: inline !important
+}


### PR DESCRIPTION
Closes #79.

Updates the display so that the main navigation menu appears on service pages.